### PR TITLE
chore: pin dependencies to immutable SHAs via ghat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
           token: ${{ github.token }}
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.8
       - run: |

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -12,9 +12,9 @@ jobs:
     # container: alpine/terragrunt:1.3.6
     steps:
       - name: "Checkout"
-        uses: actions/checkout@master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "Terragrunt Format"
-        uses: the-commons-project/terragrunt-github-actions@master
+        uses: the-commons-project/terragrunt-github-actions@96674b41c0db372843d61ed2d4708f0882753cac # 1.0.6
         with:
           tf_actions_version: ${{ env.tf_version }}
           tg_actions_version: ${{ env.tg_version }}
@@ -25,7 +25,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Terragrunt Init"
-        uses: the-commons-project/terragrunt-github-actions@master
+        uses: the-commons-project/terragrunt-github-actions@96674b41c0db372843d61ed2d4708f0882753cac # 1.0.6
         with:
           tf_actions_version: ${{ env.tf_version }}
           tg_actions_version: ${{ env.tg_version }}
@@ -35,7 +35,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Terragrunt Validate"
-        uses: the-commons-project/terragrunt-github-actions@master
+        uses: the-commons-project/terragrunt-github-actions@96674b41c0db372843d61ed2d4708f0882753cac # 1.0.6
         with:
           tf_actions_version: ${{ env.tf_version }}
           tg_actions_version: ${{ env.tg_version }}
@@ -46,7 +46,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Terragrunt Plan"
-        uses: the-commons-project/terragrunt-github-actions@master
+        uses: the-commons-project/terragrunt-github-actions@96674b41c0db372843d61ed2d4708f0882753cac # 1.0.6
         with:
           tf_actions_version: ${{ env.tf_version }}
           tg_actions_version: ${{ env.tg_version }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.8-alpine@sha256:3d93b1f77efce339aa77db726656872517b0d67837989aa7c4b35bd5ae7e81ba # 3.8-alpine
 
 RUN apk update && apk add git
 

--- a/docker/ExposePort22/positive.dockerfile
+++ b/docker/ExposePort22/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM gliderlabs/alpine:3.3@sha256:02543032e5431a50bb4c519c4974359c529d3473f844b26c297b890912f02093 # 3.3
 RUN apk --no-cache add nginx
 EXPOSE 3000 80 443 22
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/ReferenceLatestTag/failure_default_version_tag/Dockerfile
+++ b/docker/ReferenceLatestTag/failure_default_version_tag/Dockerfile
@@ -1,1 +1,1 @@
-FROM alpine
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest

--- a/docker/WorkdirIsAbsolute/positive.dockerfile
+++ b/docker/WorkdirIsAbsolute/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN pip install --upgrade pip
 WORKDIR /path/to/workdir

--- a/docker/apk_add_using_local_cache_path/positive.dockerfile
+++ b/docker/apk_add_using_local_cache_path/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM gliderlabs/alpine:3.3@sha256:02543032e5431a50bb4c519c4974359c529d3473f844b26c297b890912f02093 # 3.3
 RUN apk add --update-cache python
 WORKDIR /app
 ONBUILD COPY . /app

--- a/docker/apk_add_using_local_cache_path/test/negative.dockerfile
+++ b/docker/apk_add_using_local_cache_path/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM gliderlabs/alpine:3.3@sha256:02543032e5431a50bb4c519c4974359c529d3473f844b26c297b890912f02093 # 3.3
 RUN apk add --no-cache python
 WORKDIR /app
 ONBUILD COPY . /app

--- a/docker/apk_add_using_local_cache_path/test/positive.dockerfile
+++ b/docker/apk_add_using_local_cache_path/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM gliderlabs/alpine:3.3@sha256:02543032e5431a50bb4c519c4974359c529d3473f844b26c297b890912f02093 # 3.3
 RUN apk add --update-cache python
 WORKDIR /app
 ONBUILD COPY . /app

--- a/docker/apt_get_install_pin_version_not_defined/test/negative.dockerfile
+++ b/docker/apt_get_install_pin_version_not_defined/test/negative.dockerfile
@@ -1,2 +1,2 @@
-FROM busybox
+FROM busybox:latest@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e # latest
 RUN apt-get install python=2.7

--- a/docker/apt_get_install_pin_version_not_defined/test/positive.dockerfile
+++ b/docker/apt_get_install_pin_version_not_defined/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM busybox:latest@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e # latest
 RUN apt-get install python
 RUN ["apt-get", "install", "python"]
 

--- a/docker/apt_get_missing_yes_flag_to_avoid_manual_input/test/negative1.dockerfile
+++ b/docker/apt_get_missing_yes_flag_to_avoid_manual_input/test/negative1.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e # 12
 RUN apt-get -y install apt-utils
 RUN apt-get -qy install git gcc
 RUN ["apt-get", "-y", "install", "apt-utils"]

--- a/docker/apt_get_missing_yes_flag_to_avoid_manual_input/test/negative2.dockerfile
+++ b/docker/apt_get_missing_yes_flag_to_avoid_manual_input/test/negative2.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e # 12
 RUN sudo apt-get -y install apt-utils
 RUN sudo apt-get -qy install git gcc
 RUN ["sudo", "apt-get", "-y", "install", "apt-utils"]

--- a/docker/apt_get_missing_yes_flag_to_avoid_manual_input/test/positive1.dockerfile
+++ b/docker/apt_get_missing_yes_flag_to_avoid_manual_input/test/positive1.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e # 12
 RUN apt-get install python=2.7
 RUN apt-get install apt-utils
 RUN ["apt-get", "install", "apt-utils"]

--- a/docker/apt_get_missing_yes_flag_to_avoid_manual_input/test/positive2.dockerfile
+++ b/docker/apt_get_missing_yes_flag_to_avoid_manual_input/test/positive2.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e # 12
 RUN sudo apt-get install python=2.7
 RUN sudo apt-get install apt-utils
 RUN ["sudo", "apt-get", "install", "apt-utils"]

--- a/docker/apt_get_missing_yes_flag_to_avoid_manual_input/test/positive3.dockerfile
+++ b/docker/apt_get_missing_yes_flag_to_avoid_manual_input/test/positive3.dockerfile
@@ -1,2 +1,2 @@
-FROM node:12
+FROM node:12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e # 12
 RUN DUMMY=test apt-get install python=2.7

--- a/docker/apt_get_not_avoiding_additional_packages/test/negative.dockerfile
+++ b/docker/apt_get_not_avoiding_additional_packages/test/negative.dockerfile
@@ -1,3 +1,3 @@
-FROM node:12
+FROM node:12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e # 12
 RUN apt-get --no-install-recommends install apt-utils
 RUN ["apt-get", "apt::install-recommends=false", "install", "apt-utils"]

--- a/docker/apt_get_not_avoiding_additional_packages/test/positive.dockerfile
+++ b/docker/apt_get_not_avoiding_additional_packages/test/positive.dockerfile
@@ -1,3 +1,3 @@
-FROM node:12
+FROM node:12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e # 12
 RUN apt-get install apt-utils
 RUN ["apt-get", "install", "apt-utils"]

--- a/docker/changing_default_shell_using_shell_command/test/negative.dockerfile
+++ b/docker/changing_default_shell_using_shell_command/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN sudo yum install -y bundler
 RUN yum install

--- a/docker/changing_default_shell_using_shell_command/test/positive.dockerfile
+++ b/docker/changing_default_shell_using_shell_command/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN sudo yum install -y bundler
 RUN yum install

--- a/docker/chown_flag_exists/test/negative.dockerfile
+++ b/docker/chown_flag_exists/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7@sha256:eedf63967cdb57d8214db38ce21f105003ed4e4d0358f02bedc057341bcf92a0 # 3.7
 RUN pip install Flask==0.11.1
 RUN useradd -ms /bin/bash patrick
 COPY app /app

--- a/docker/chown_flag_exists/test/positive.dockerfile
+++ b/docker/chown_flag_exists/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7@sha256:eedf63967cdb57d8214db38ce21f105003ed4e4d0358f02bedc057341bcf92a0 # 3.7
 RUN pip install Flask==0.11.1
 RUN useradd -ms /bin/bash patrick
 COPY --chown=patrick:patrick app /app

--- a/docker/copy_from_references_current_from_alias/test/negative.dockerfile
+++ b/docker/copy_from_references_current_from_alias/test/negative.dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.7.3 AS builder
+FROM golang:1.7.3@sha256:340212e9c5d062f3bfe58ff02768da70234ea734bd022a357ee6be2a6d963505 AS builder # 1.7.3
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
 # another dockerfile
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/alexellis/href-counter/app .

--- a/docker/copy_from_without_from_alias_defined_previously/test/negative.dockerfile
+++ b/docker/copy_from_without_from_alias_defined_previously/test/negative.dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.7.3 AS builder
+FROM golang:1.7.3@sha256:340212e9c5d062f3bfe58ff02768da70234ea734bd022a357ee6be2a6d963505 AS builder # 1.7.3
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
 # another dockerfile
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/alexellis/href-counter/app .

--- a/docker/copy_from_without_from_alias_defined_previously/test/positive.dockerfile
+++ b/docker/copy_from_without_from_alias_defined_previously/test/positive.dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.7.3 AS builder
+FROM golang:1.7.3@sha256:340212e9c5d062f3bfe58ff02768da70234ea734bd022a357ee6be2a6d963505 AS builder # 1.7.3
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder2 /go/src/github.com/alexellis/href-counter/app .

--- a/docker/copy_with_more_than_two_arguments_not_ending_with_slash/test/negative1.dockerfile
+++ b/docker/copy_with_more_than_two_arguments_not_ending_with_slash/test/negative1.dockerfile
@@ -1,2 +1,2 @@
-FROM node:carbon
+FROM node:carbon@sha256:a681bf74805b80d03eb21a6c0ef168a976108a287a74167ab593fc953aac34df # carbon
 COPY package.json yarn.lock my_app/

--- a/docker/gem_install_without_version/test/negative.dockerfile
+++ b/docker/gem_install_without_version/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN gem install bundler:2.0.2
 RUN bundle install

--- a/docker/gem_install_without_version/test/positive.dockerfile
+++ b/docker/gem_install_without_version/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN gem install bundler
 RUN ["gem", "install", "blunder"]

--- a/docker/image_version_not_explicit/test/negative.dockerfile
+++ b/docker/image_version_not_explicit/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN pip install --upgrade pip
 COPY requirements.txt /usr/src/app/
@@ -7,5 +7,5 @@ COPY app.py /usr/src/app/
 COPY templates/index.html /usr/src/app/templates/
 EXPOSE 5000
 ARG IMAGE=alpine:3.12
-FROM $IMAGE
+FROM $IMAGE@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69 # 3.12
 CMD ["python", "/usr/src/app/app.py"]

--- a/docker/image_version_not_explicit/test/positive.dockerfile
+++ b/docker/image_version_not_explicit/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk add --update py2-pip
 RUN pip install --upgrade pip
 COPY requirements.txt /usr/src/app/

--- a/docker/image_version_using_latest/test/negative.dockerfile
+++ b/docker/image_version_using_latest/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN pip install --upgrade pip
 COPY requirements.txt /usr/src/app/

--- a/docker/image_version_using_latest/test/positive.dockerfile
+++ b/docker/image_version_using_latest/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk add --update py2-pip
 RUN pip install --upgrade pip
 COPY requirements.txt /usr/src/app/

--- a/docker/last_user_is_root/test/negative.dockerfile
+++ b/docker/last_user_is_root/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:2.6
+FROM alpine:2.6@sha256:e9cec9aec697d8b9d450edd32860ecd363f2f3174c8338beb5f809422d182c63 # 2.6
 USER root
 RUN npm install
 USER guest

--- a/docker/last_user_is_root/test/negative2.dockerfile
+++ b/docker/last_user_is_root/test/negative2.dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.16 AS builder
+FROM golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e AS builder # 1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 USER root
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./

--- a/docker/last_user_is_root/test/positive.dockerfile
+++ b/docker/last_user_is_root/test/positive.dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:2.6
+FROM alpine:2.6@sha256:e9cec9aec697d8b9d450edd32860ecd363f2f3174c8338beb5f809422d182c63 # 2.6
 USER root
 RUN npm install

--- a/docker/missing_dnf_clean_all/test/negative.dockerfile
+++ b/docker/missing_dnf_clean_all/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:27
+FROM fedora:27@sha256:d9697056b7add7d075b02d1920ec6b587063ac93fe21d83a354b3220ba18bc02 # 27
 RUN set -uex && \
     dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo && \
     sed -i 's/\$releasever/26/g' /etc/yum.repos.d/docker-ce.repo && \

--- a/docker/missing_dnf_clean_all/test/negative2.dockerfile
+++ b/docker/missing_dnf_clean_all/test/negative2.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 AS builder
+FROM golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e AS builder # 1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    ./
@@ -8,7 +8,7 @@ RUN set -uex && \
     sed -i 's/\$releasever/26/g' /etc/yum.repos.d/docker-ce.repo && \
     dnf install -vy docker-ce
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./

--- a/docker/missing_dnf_clean_all/test/positive.dockerfile
+++ b/docker/missing_dnf_clean_all/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:27
+FROM fedora:27@sha256:d9697056b7add7d075b02d1920ec6b587063ac93fe21d83a354b3220ba18bc02 # 27
 RUN set -uex && \
     dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo && \
     sed -i 's/\$releasever/26/g' /etc/yum.repos.d/docker-ce.repo && \

--- a/docker/missing_flag_from_dnf_install/test/negative.dockerfile
+++ b/docker/missing_flag_from_dnf_install/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:27
+FROM fedora:27@sha256:d9697056b7add7d075b02d1920ec6b587063ac93fe21d83a354b3220ba18bc02 # 27
 RUN set -uex && \
     dnf config-manager --set-enabled docker-ce-test && \
     dnf install -y docker-ce && \

--- a/docker/missing_flag_from_dnf_install/test/positive.dockerfile
+++ b/docker/missing_flag_from_dnf_install/test/positive.dockerfile
@@ -1,10 +1,10 @@
-FROM fedora:27
+FROM fedora:27@sha256:d9697056b7add7d075b02d1920ec6b587063ac93fe21d83a354b3220ba18bc02 # 27
 RUN set -uex && \
     dnf config-manager --set-enabled docker-ce-test && \
     dnf install docker-ce && \
     dnf clean all
 
-FROM fedora:28
+FROM fedora:28@sha256:5593a1e2fe65db0e199faca916b5ce7494a9f0e29b7be9f529fb69d1e8ef42d1 # 28
 RUN set -uex
 RUN dnf config-manager --set-enabled docker-ce-test
 RUN dnf in docker-ce

--- a/docker/missing_user_instruction/test/negative.dockerfile
+++ b/docker/missing_user_instruction/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7@sha256:cfa62318c459b1fde9e0841c619906d15ada5910d625176e24bf692cf8a2601d # 2.7
 RUN pip install Flask==0.11.1
 RUN useradd -ms /bin/bash patrick
 COPY --chown=patrick:patrick app /app

--- a/docker/missing_user_instruction/test/negative2.dockerfile
+++ b/docker/missing_user_instruction/test/negative2.dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.16 AS builder
+FROM golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e AS builder # 1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./

--- a/docker/missing_user_instruction/test/negative3.dockerfile
+++ b/docker/missing_user_instruction/test/negative3.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7@sha256:cfa62318c459b1fde9e0841c619906d15ada5910d625176e24bf692cf8a2601d # 2.7
 RUN pip install Flask==0.11.1
 RUN useradd -ms /bin/bash patrick
 COPY --chown=patrick:patrick app /app

--- a/docker/missing_user_instruction/test/positive.dockerfile
+++ b/docker/missing_user_instruction/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7@sha256:cfa62318c459b1fde9e0841c619906d15ada5910d625176e24bf692cf8a2601d # 2.7
 RUN pip install Flask==0.11.1
 RUN useradd -ms /bin/bash patrick
 COPY --chown=patrick:patrick app /app

--- a/docker/missing_user_instruction/test/positive2.dockerfile
+++ b/docker/missing_user_instruction/test/positive2.dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.16 AS builder
+FROM golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e AS builder # 1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./

--- a/docker/missing_version_specification_in_dnf_install/test/negative.dockerfile
+++ b/docker/missing_version_specification_in_dnf_install/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:latest@sha256:498c452f32a739b61f0ef215bce9924ebc4866cbe44710f58157d77723b7a6d2 # latest
 RUN dnf -y update && dnf -y install httpd-2.24.2 && dnf clean all
 RUN ["dnf", "install", "httpd-2.24.2"]
 COPY index.html /var/www/html/index.html

--- a/docker/missing_version_specification_in_dnf_install/test/positive.dockerfile
+++ b/docker/missing_version_specification_in_dnf_install/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:latest@sha256:498c452f32a739b61f0ef215bce9924ebc4866cbe44710f58157d77723b7a6d2 # latest
 RUN dnf -y update && dnf -y install httpd && dnf clean all
 RUN ["dnf", "install", "httpd"]
 COPY index.html /var/www/html/index.html

--- a/docker/missing_zypper_clean/test/negative2.dockerfile
+++ b/docker/missing_zypper_clean/test/negative2.dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.16 AS builder
+FROM golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e AS builder # 1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 RUN zypper install
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./

--- a/docker/missing_zypper_non_interactive_switch/test/negative2.dockerfile
+++ b/docker/missing_zypper_non_interactive_switch/test/negative2.dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.16 AS builder
+FROM golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e AS builder # 1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 RUN zypper install httpd && zypper clean
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./

--- a/docker/multiple_cmd_instructions_listed/positive.dockerfile
+++ b/docker/multiple_cmd_instructions_listed/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.3
+FROM golang:1.7.3@sha256:340212e9c5d062f3bfe58ff02768da70234ea734bd022a357ee6be2a6d963505 # 1.7.3
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go .
@@ -6,7 +6,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 CMD ["./app"]
 CMD ["./apps"]
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/alexellis/href-counter/app .

--- a/docker/multiple_cmd_instructions_listed/test/negative.dockerfile
+++ b/docker/multiple_cmd_instructions_listed/test/negative.dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.7.3
+FROM golang:1.7.3@sha256:340212e9c5d062f3bfe58ff02768da70234ea734bd022a357ee6be2a6d963505 # 1.7.3
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 CMD ["./app"]
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/alexellis/href-counter/app .

--- a/docker/multiple_cmd_instructions_listed/test/negative2.dockerfile
+++ b/docker/multiple_cmd_instructions_listed/test/negative2.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 AS builder
+FROM golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e AS builder # 1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    ./
@@ -6,7 +6,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 CMD ["./app"]
 CMD ["./apps"]
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./

--- a/docker/multiple_cmd_instructions_listed/test/positive.dockerfile
+++ b/docker/multiple_cmd_instructions_listed/test/positive.dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.7.3
+FROM golang:1.7.3@sha256:340212e9c5d062f3bfe58ff02768da70234ea734bd022a357ee6be2a6d963505 # 1.7.3
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/alexellis/href-counter/app .

--- a/docker/multiple_entrypoint_instructions_listed/test/negative.dockerfile
+++ b/docker/multiple_entrypoint_instructions_listed/test/negative.dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.7.3
+FROM golang:1.7.3@sha256:340212e9c5d062f3bfe58ff02768da70234ea734bd022a357ee6be2a6d963505 # 1.7.3
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 ENTRYPOINT [ "/opt/app/run.sh", "--port", "8080" ]
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/alexellis/href-counter/app .

--- a/docker/multiple_entrypoint_instructions_listed/test/negative2.dockerfile
+++ b/docker/multiple_entrypoint_instructions_listed/test/negative2.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 AS builder
+FROM golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e AS builder # 1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    ./
@@ -6,7 +6,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 ENTRYPOINT [ "/opt/app/run.sh", "--port", "8080" ]
 ENTRYPOINT [ "/opt/app/run.sh", "--port", "8000" ]
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./

--- a/docker/multiple_entrypoint_instructions_listed/test/positive.dockerfile
+++ b/docker/multiple_entrypoint_instructions_listed/test/positive.dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.7.3
+FROM golang:1.7.3@sha256:340212e9c5d062f3bfe58ff02768da70234ea734bd022a357ee6be2a6d963505 # 1.7.3
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/alexellis/href-counter/app .

--- a/docker/multiple_run_add_copy_instructions_listed/test/negative1.dockerfile
+++ b/docker/multiple_run_add_copy_instructions_listed/test/negative1.dockerfile
@@ -1,2 +1,2 @@
-FROM ubuntu
+FROM ubuntu:latest@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b # latest
 RUN apt-get install wget && wget https://…/downloadedfile.tar && tar xvzf downloadedfile.tar && rm downloadedfile.tar && apt-get remove wget

--- a/docker/multiple_run_add_copy_instructions_listed/test/negative2.dockerfile
+++ b/docker/multiple_run_add_copy_instructions_listed/test/negative2.dockerfile
@@ -1,2 +1,2 @@
-FROM ubuntu
+FROM ubuntu:latest@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b # latest
 COPY README.md package.json gulpfile.js __BUILD_NUMBER ./

--- a/docker/multiple_run_add_copy_instructions_listed/test/negative3.dockerfile
+++ b/docker/multiple_run_add_copy_instructions_listed/test/negative3.dockerfile
@@ -1,2 +1,2 @@
-FROM ubuntu
+FROM ubuntu:latest@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b # latest
 ADD cairo.spec cairo-1.13.1.tar.xz cairo-multilib.patch  /rpmbuild/SOURCES

--- a/docker/multiple_run_add_copy_instructions_listed/test/negative4.dockerfile
+++ b/docker/multiple_run_add_copy_instructions_listed/test/negative4.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:latest@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b # latest
 COPY README.md ./one
 COPY package.json ./two
 COPY gulpfile.js ./three

--- a/docker/multiple_run_add_copy_instructions_listed/test/negative5.dockerfile
+++ b/docker/multiple_run_add_copy_instructions_listed/test/negative5.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 AS builder
+FROM golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e AS builder # 1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    ./
@@ -6,7 +6,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 ADD cairo.spec /rpmbuild/SOURCES
 ADD cairo-1.13.1.tar.xz /rpmbuild/SOURCES
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./

--- a/docker/multiple_run_add_copy_instructions_listed/test/positive1.dockerfile
+++ b/docker/multiple_run_add_copy_instructions_listed/test/positive1.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:latest@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b # latest
 RUN apt-get install -y wget
 RUN wget https://…/downloadedfile.tar
 RUN tar xvzf downloadedfile.tar

--- a/docker/multiple_run_add_copy_instructions_listed/test/positive2.dockerfile
+++ b/docker/multiple_run_add_copy_instructions_listed/test/positive2.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:latest@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b # latest
 COPY README.md ./
 COPY package.json ./
 COPY gulpfile.js ./

--- a/docker/multiple_run_add_copy_instructions_listed/test/positive3.dockerfile
+++ b/docker/multiple_run_add_copy_instructions_listed/test/positive3.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:latest@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b # latest
 ADD cairo.spec /rpmbuild/SOURCES
 ADD cairo-1.13.1.tar.xz /rpmbuild/SOURCES
 ADD cairo-multilib.patch /rpmbuild/SOURCES

--- a/docker/not_using_json_in_cmd_and_entrypoint_arguments/test/negative.dockerfile
+++ b/docker/not_using_json_in_cmd_and_entrypoint_arguments/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN sudo yum install bundler
 RUN yum install

--- a/docker/not_using_json_in_cmd_and_entrypoint_arguments/test/negative2.dockerfile
+++ b/docker/not_using_json_in_cmd_and_entrypoint_arguments/test/negative2.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 AS builder
+FROM golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e AS builder # 1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    ./
@@ -6,7 +6,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 CMD [python, /usr/src/app/app.py]
 ENTRYPOINT [top, -b]
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./

--- a/docker/not_using_json_in_cmd_and_entrypoint_arguments/test/positive.dockerfile
+++ b/docker/not_using_json_in_cmd_and_entrypoint_arguments/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN sudo yum install bundler
 RUN yum install

--- a/docker/npm_install_without_pinned_version/positive.dockerfile
+++ b/docker/npm_install_without_pinned_version/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e # 12
 RUN npm install sax
 RUN npm install sax --no-cache
 RUN npm install sax | grep fail && npm install sax@latest

--- a/docker/npm_install_without_pinned_version/test/negative.dockerfile
+++ b/docker/npm_install_without_pinned_version/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e # 12
 RUN npm install
 RUN npm install sax@latest
 RUN npm install sax@0.1.1

--- a/docker/npm_install_without_pinned_version/test/positive.dockerfile
+++ b/docker/npm_install_without_pinned_version/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e # 12
 RUN npm install sax
 RUN npm install sax --no-cache
 RUN npm install sax | grep fail && npm install sax@latest

--- a/docker/pip_install_keeping_cached_packages/test/negative.dockerfile
+++ b/docker/pip_install_keeping_cached_packages/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3@sha256:0ba001803c72c128063cfa88863755f905cefabe73c026c66a5a86d8f1d63e98 # 3
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir nibabel pydicom matplotlib pillow && \
     pip install --no-cache-dir med2image

--- a/docker/pip_install_keeping_cached_packages/test/positive.dockerfile
+++ b/docker/pip_install_keeping_cached_packages/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3@sha256:0ba001803c72c128063cfa88863755f905cefabe73c026c66a5a86d8f1d63e98 # 3
 RUN pip install --upgrade pip && \
     pip install nibabel pydicom matplotlib pillow && \
     pip install med2image

--- a/docker/run_command_cd_instead_of_workdir/test/negative.dockerfile
+++ b/docker/run_command_cd_instead_of_workdir/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM nginx:latest@sha256:6e23479198b998e5e25921dff8455837c7636a67111a04a635cf1bb363d199dc # latest
 ENV AUTHOR=Docker
 WORKDIR /usr/share/nginx/html
 COPY Hello_docker.html /usr/share/nginx/html

--- a/docker/run_command_cd_instead_of_workdir/test/positive.dockerfile
+++ b/docker/run_command_cd_instead_of_workdir/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM nginx:latest@sha256:6e23479198b998e5e25921dff8455837c7636a67111a04a635cf1bb363d199dc # latest
 ENV AUTHOR=Docker
 RUN cd /usr/share/nginx/html
 COPY Hello_docker.html /usr/share/nginx/html

--- a/docker/run_using_sudo/test/negative.dockerfile
+++ b/docker/run_using_sudo/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN pip install --upgrade pip
 RUN apt-get install sudo

--- a/docker/run_using_sudo/test/positive.dockerfile
+++ b/docker/run_using_sudo/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN sudo pip install --upgrade pip
 COPY requirements.txt /usr/src/app/

--- a/docker/run_using_wget_and_curl/test/negative.dockerfile
+++ b/docker/run_using_wget_and_curl/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM debian:latest@sha256:35b8ff74ead4880f22090b617372daff0ccae742eb5674455d542bef71ef1999 # latest
 RUN curl http://google.com
 RUN curl http://bing.com
 RUN ["curl", "http://bing.com"]

--- a/docker/run_using_wget_and_curl/test/positive.dockerfile
+++ b/docker/run_using_wget_and_curl/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM debian:latest@sha256:35b8ff74ead4880f22090b617372daff0ccae742eb5674455d542bef71ef1999 # latest
 RUN wget http://google.com
 RUN curl http://bing.com
 

--- a/docker/run_utilities_and_posix_commands/test/negative.dockerfile
+++ b/docker/run_utilities_and_posix_commands/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:latest@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b # latest
 RUN apt-get update && apt-get install -y x11vnc xvfb firefox
 RUN mkdir ~/.vnc
 RUN x11vnc -storepasswd 1234 ~/.vnc/passwd

--- a/docker/run_utilities_and_posix_commands/test/positive.dockerfile
+++ b/docker/run_utilities_and_posix_commands/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.0-stretch
+FROM golang:1.12.0-stretch@sha256:25cadebaee179273407abe188337b857d850521f750cf29dfbc89d02441aab08 # 1.12.0-stretch
 WORKDIR /go
 COPY . /go
 RUN top

--- a/docker/shell_running_a_pipe_without_pipefail_flag/test/negative.dockerfile
+++ b/docker/shell_running_a_pipe_without_pipefail_flag/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e # 12
 RUN pwsh SOME_CMD | SOME_OTHER_CMD
 SHELL [ "zsh", "-o","pipefail" ]
 RUN zsh ./some_output | ./some_script

--- a/docker/shell_running_a_pipe_without_pipefail_flag/test/positive.dockerfile
+++ b/docker/shell_running_a_pipe_without_pipefail_flag/test/positive.dockerfile
@@ -1,3 +1,3 @@
-FROM node:12
+FROM node:12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e # 12
 RUN zsh ./some_output | ./some_script
 RUN [ "/bin/bash", "./some_output", "|", "./some_script" ]

--- a/docker/unix_ports_out_of_range/test/negative.dockerfile
+++ b/docker/unix_ports_out_of_range/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM gliderlabs/alpine:3.3@sha256:02543032e5431a50bb4c519c4974359c529d3473f844b26c297b890912f02093 # 3.3
 RUN apk --no-cache add nginx
 EXPOSE 3000 80 443 22
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/unix_ports_out_of_range/test/positive.dockerfile
+++ b/docker/unix_ports_out_of_range/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM gliderlabs/alpine:3.3@sha256:02543032e5431a50bb4c519c4974359c529d3473f844b26c297b890912f02093 # 3.3
 RUN apk --no-cache add nginx
 EXPOSE 65536/tcp 80 443 22
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/unpinned_package_version_in_apk_add/test/negative.dockerfile
+++ b/docker/unpinned_package_version_in_apk_add/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.4@sha256:b733d4a32c4da6a00a84df2ca32791bb03df95400243648d8c539e7b4cce329c # 3.4
 RUN apk add --update py-pip=7.1.2-r0
 RUN sudo pip install --upgrade pip
 COPY requirements.txt /usr/src/app/
@@ -8,7 +8,7 @@ COPY templates/index.html /usr/src/app/templates/
 EXPOSE 5000
 CMD ["python", "/usr/src/app/app.py"]
 
-FROM alpine:3.1
+FROM alpine:3.1@sha256:4dfc68bc95af5c1beb5e307133ce91546874dcd0d880736b25ddbe6f483c65b4 # 3.1
 RUN apk add py-pip=7.1.2-r0
 RUN ["apk", "add", "py-pip=7.1.2-r0"]
 RUN sudo pip install --upgrade pip

--- a/docker/unpinned_package_version_in_apk_add/test/positive.dockerfile
+++ b/docker/unpinned_package_version_in_apk_add/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.9@sha256:414e0518bb9228d35e4cd5165567fb91d26c6a214e9c95899e1e056fcd349011 # 3.9
 RUN apk add --update py-pip
 RUN sudo pip install --upgrade pip
 COPY requirements.txt /usr/src/app/
@@ -9,7 +9,7 @@ EXPOSE 5000
 ENV TEST="test"
 CMD ["python", "/usr/src/app/app.py"]
 
-FROM alpine:3.7
+FROM alpine:3.7@sha256:8421d9a84432575381bfabd248f1eb56f3aa21d9d7cd2511583c68c9b7511d10 # 3.7
 RUN apk add py-pip && apk add tea
 RUN apk add py-pip \
     && rm -rf /tmp/*

--- a/docker/unpinned_package_version_in_pip_install/test/negative.dockerfile
+++ b/docker/unpinned_package_version_in_pip_install/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.4@sha256:b733d4a32c4da6a00a84df2ca32791bb03df95400243648d8c539e7b4cce329c # 3.4
 RUN apk add --update py-pip=7.1.2-r0
 RUN sudo pip install --upgrade pip=20.3 connexion=2.7.0
 COPY requirements.txt /usr/src/app/
@@ -8,7 +8,7 @@ COPY templates/index.html /usr/src/app/templates/
 EXPOSE 5000
 CMD ["python", "/usr/src/app/app.py"]
 
-FROM alpine:3.1
+FROM alpine:3.1@sha256:4dfc68bc95af5c1beb5e307133ce91546874dcd0d880736b25ddbe6f483c65b4 # 3.1
 RUN apk add py-pip=7.1.2-r0
 RUN sudo pip install --upgrade pip=20.3 connexion=2.7.0
 COPY requirements.txt /usr/src/app/

--- a/docker/unpinned_package_version_in_pip_install/test/positive.dockerfile
+++ b/docker/unpinned_package_version_in_pip_install/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.9@sha256:414e0518bb9228d35e4cd5165567fb91d26c6a214e9c95899e1e056fcd349011 # 3.9
 RUN apk add --update py-pip=7.1.2-r0
 RUN pip install --user pip
 RUN ["pip", "install", "connexion"]
@@ -10,7 +10,7 @@ EXPOSE 5000
 ENV TEST="test"
 CMD ["python", "/usr/src/app/app.py"]
 
-FROM alpine:3.7
+FROM alpine:3.7@sha256:8421d9a84432575381bfabd248f1eb56f3aa21d9d7cd2511583c68c9b7511d10 # 3.7
 RUN apk add --update py-pip=7.1.2-r0
 RUN pip install connexion
 COPY requirements.txt /usr/src/app/

--- a/docker/using_platform_with_from/test/negative.dockerfile
+++ b/docker/using_platform_with_from/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN pip install --upgrade pip
 LABEL maintainer="SvenDowideit@home.org.au"

--- a/docker/using_platform_with_from/test/positive.dockerfile
+++ b/docker/using_platform_with_from/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN pip install --upgrade pip
 LABEL maintainer="SvenDowideit@home.org.au"

--- a/docker/yum_clean_all_missing/test/negative.dockerfile
+++ b/docker/yum_clean_all_missing/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN yum install \
     yum clean all
@@ -9,6 +9,6 @@ COPY templates/index.html /usr/src/app/templates/
 EXPOSE 5000
 CMD ["python", "/usr/src/app/app.py"]
 
-FROM alpine:3.4
+FROM alpine:3.4@sha256:b733d4a32c4da6a00a84df2ca32791bb03df95400243648d8c539e7b4cce329c # 3.4
 RUN yum -y install \
     yum clean all

--- a/docker/yum_clean_all_missing/test/negative2.dockerfile
+++ b/docker/yum_clean_all_missing/test/negative2.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 AS builder
+FROM golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e AS builder # 1.16
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html
 COPY app.go    ./
@@ -6,7 +6,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 RUN yum clean all \
     yum -y install
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./

--- a/docker/yum_clean_all_missing/test/positive.dockerfile
+++ b/docker/yum_clean_all_missing/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN yum install
 COPY requirements.txt /usr/src/app/
@@ -8,6 +8,6 @@ COPY templates/index.html /usr/src/app/templates/
 EXPOSE 5000
 CMD ["python", "/usr/src/app/app.py"]
 
-FROM alpine:3.4
+FROM alpine:3.4@sha256:b733d4a32c4da6a00a84df2ca32791bb03df95400243648d8c539e7b4cce329c # 3.4
 RUN yum clean all \
     yum -y install

--- a/docker/yum_install_allows_manual_input/test/negative.dockerfile
+++ b/docker/yum_install_allows_manual_input/test/negative.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN sudo yum install -y bundler
 COPY requirements.txt /usr/src/app/

--- a/docker/yum_install_allows_manual_input/test/positive.dockerfile
+++ b/docker/yum_install_allows_manual_input/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec # 3.5
 RUN apk add --update py2-pip
 RUN sudo yum install bundler
 RUN ["sudo yum", "install", "bundler"]

--- a/docker/yum_install_without_version/test/negative.dockerfile
+++ b/docker/yum_install_without_version/test/negative.dockerfile
@@ -1,8 +1,8 @@
-FROM opensuse/leap:15.2
+FROM opensuse/leap:15.2@sha256:dfa464ed7bc25fb77ad652d4e722cb0e78fc230425846be10e51dda1f43aa5c9 # 15.2
 RUN yum install -y httpd-2.24.2 && yum clean all
 HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1
 
 
-FROM opensuse/leap:15.3
+FROM opensuse/leap:15.3@sha256:ce397977a1a7735cdaf662dcc98039c5083e69054788b24e7d6a92c19f190fcd # 15.3
 ENV RETHINKDB_PACKAGE_VERSION 2.4.0~0trusty
 RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION && yum clean all

--- a/docker/yum_install_without_version/test/positive.dockerfile
+++ b/docker/yum_install_without_version/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.2
+FROM opensuse/leap:15.2@sha256:dfa464ed7bc25fb77ad652d4e722cb0e78fc230425846be10e51dda1f43aa5c9 # 15.2
 RUN yum install -y httpd && yum clean all
 RUN ["yum", "install", "httpd"]
 HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1

--- a/docker/zypper_install_without_version/test/negative.dockerfile
+++ b/docker/zypper_install_without_version/test/negative.dockerfile
@@ -1,3 +1,3 @@
-FROM opensuse/leap:15.2
+FROM opensuse/leap:15.2@sha256:dfa464ed7bc25fb77ad652d4e722cb0e78fc230425846be10e51dda1f43aa5c9 # 15.2
 RUN zypper install -y httpd=2.4.46 && zypper clean
 HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1

--- a/docker/zypper_install_without_version/test/positive.dockerfile
+++ b/docker/zypper_install_without_version/test/positive.dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.2
+FROM opensuse/leap:15.2@sha256:dfa464ed7bc25fb77ad652d4e722cb0e78fc230425846be10e51dda1f43aa5c9 # 15.2
 RUN zypper install -y httpd && zypper clean
 RUN ["zypper", "install", "http"]
 HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1

--- a/kubernetes/AllowedCapabilities/cassandra-FAILED.yaml
+++ b/kubernetes/AllowedCapabilities/cassandra-FAILED.yaml
@@ -34,7 +34,7 @@ spec:
       terminationGracePeriodSeconds: 1800
       containers:
       - name: cassandra
-        image: gcr.io/google-samples/cassandra:v13
+        image: gcr.io/google-samples/cassandra@sha256:7a3d20afa0a46ed073a5c587b4f37e21fa860e83c60b9c42fec1e1e739d64007 # v13
         imagePullPolicy: Always
         ports:
         - containerPort: 7000
@@ -95,7 +95,7 @@ spec:
         - name: cassandra-data
           mountPath: /cassandra_data
       - name: cassandra
-        image: gcr.io/google-samples/cassandra:v13
+        image: gcr.io/google-samples/cassandra@sha256:7a3d20afa0a46ed073a5c587b4f37e21fa860e83c60b9c42fec1e1e739d64007 # v13
         imagePullPolicy: Always
         ports:
         - containerPort: 7000

--- a/kubernetes/DefaultNamespace/nginx-statefulset-FAILED.yaml
+++ b/kubernetes/DefaultNamespace/nginx-statefulset-FAILED.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: k8s.gcr.io/nginx-slim@sha256:8b4501fe0fe221df663c22e16539f399e89594552f400408303c42f3dd8d0e52 # 0.8
         ports:
         - containerPort: 80
           name: web

--- a/kubernetes/PrivilegedContainers/privilegedPod-FAILED.yaml
+++ b/kubernetes/PrivilegedContainers/privilegedPod-FAILED.yaml
@@ -5,8 +5,8 @@ metadata:
   name: privileged
 spec:
   containers:
-  - name: busybox
-    image: busybox
+  - name: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e # latest
+    image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e # latest
     resources:
       limits:
         cpu: 200m

--- a/kubernetes/RootContainers/rootContainersFAILED.yaml
+++ b/kubernetes/RootContainers/rootContainersFAILED.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: main
-    image: alpine
+    image: alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
     command: ["/bin/sleep", "999999"]
 ---
 # runAsNonRoot set at pod, but overridden at container
@@ -19,7 +19,7 @@ spec:
     runAsNonRoot: true
   containers:
   - name: main
-    image: alpine
+    image: alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
     command: ["/bin/sleep", "999999"]
     securityContext:
       runAsNonRoot: false
@@ -34,7 +34,7 @@ spec:
     runAsUser: 0
   containers:
   - name: main
-    image: alpine
+    image: alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
     command: ["/bin/sleep", "999999"]
 ---
 # runAsNonRoot not set, runAsUser >1000 defined at pod, but overridden to 0 at container level
@@ -47,10 +47,10 @@ spec:
     runAsUser: 1000
   containers:
   - name: main
-    image: alpine
+    image: alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
     command: ["/bin/sleep", "999999"]
   - name: main2
-    image: alpine
+    image: alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
     command: ["/bin/sleep", "999999"]
     securityContext:
       runAsUser: 0

--- a/kubernetes/ShareHostIPCPSP/privilegedDaemonSet-FAILED.yaml
+++ b/kubernetes/ShareHostIPCPSP/privilegedDaemonSet-FAILED.yaml
@@ -13,8 +13,8 @@ spec:
         name: privileged-container
     spec:
       containers:
-      - name: busybox
-        image: busybox
+      - name: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e # latest
+        image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e # latest
         resources:
           limits:
             cpu: 200m

--- a/kubernetes/ShareHostIPCPSP/privilegedPod-FAILED.yaml
+++ b/kubernetes/ShareHostIPCPSP/privilegedPod-FAILED.yaml
@@ -5,8 +5,8 @@ metadata:
   name: privileged
 spec:
   containers:
-  - name: busybox
-    image: busybox
+  - name: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e # latest
+    image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e # latest
     resources:
       limits:
         cpu: 200m

--- a/kubernetes/example_AllowedCapabilitiesSysAdmin/pod-FAILED.yaml
+++ b/kubernetes/example_AllowedCapabilitiesSysAdmin/pod-FAILED.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: sec-ctx-1
-      image: gcr.io/google-samples/node-hello:1.0
+      image: gcr.io/google-samples/node-hello@sha256:d238d0ab54efb76ec0f7b1da666cefa9b40be59ef34346a761b8adc2dd45459b # 1.0
       securityContext:
         capabilities:
           add: ["SYS_ADMIN"]

--- a/kubernetes/example_ApiServerAdmissionControlAlwaysAdmit/ApiServerAdmissionControlAlwaysAdmit-FAILED.yaml
+++ b/kubernetes/example_ApiServerAdmissionControlAlwaysAdmit/ApiServerAdmissionControlAlwaysAdmit-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
     - command:
         - kube-apiserver
         - --enable-admission-plugins=AlwaysAdmit
-      image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+      image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
       livenessProbe:
         failureThreshold: 8
         httpGet:

--- a/kubernetes/example_ApiServerAlwaysPullImagesPlugin/ApiServerAlwaysPullImagesPlugin-FAILED.yaml
+++ b/kubernetes/example_ApiServerAlwaysPullImagesPlugin/ApiServerAlwaysPullImagesPlugin-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --enable-admission-plugins=other
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAnonymousAuth/ApiServer-AnonymousAuth-True-FAILED.yaml
+++ b/kubernetes/example_ApiServerAnonymousAuth/ApiServer-AnonymousAuth-True-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --anonymous-auth=true
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuditLog/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuditLog/ApiServer-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuditLogMaxAge/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuditLogMaxAge/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --audit-log-maxage=10
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuditLogMaxBackup/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuditLogMaxBackup/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --profiling=true
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuditLogMaxSize/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuditLogMaxSize/ApiServer-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuthorizationModeNode/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuthorizationModeNode/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --authorization-mode=RBAC
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuthorizationModeNotAlwaysAllow/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuthorizationModeNotAlwaysAllow/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --authorization-mode=AlwaysAllow
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuthorizationModeRBAC/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuthorizationModeRBAC/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --authorization-mode=Node
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerBasicAuthFile/ApiServerBasicAuthFile-FAILED.yaml
+++ b/kubernetes/example_ApiServerBasicAuthFile/ApiServerBasicAuthFile-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --basic-auth-file=some_file
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerEncryptionProviders/ApiServerEncryptionProviders-FAILED.yaml
+++ b/kubernetes/example_ApiServerEncryptionProviders/ApiServerEncryptionProviders-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerEtcdCaFile/example_ApiServerEtcdCaFile-FAILED.yaml
+++ b/kubernetes/example_ApiServerEtcdCaFile/example_ApiServerEtcdCaFile-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerEtcdCertAndKey/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerEtcdCertAndKey/ApiServer-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerKubeletClientCertAndKey/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerKubeletClientCertAndKey/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --kubelet-client-certificate=/path/to/cert
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerKubeletHttps/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerKubeletHttps/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --kubelet-https=false
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerNamespaceLifecyclePlugin/ApiServerNamespaceLifecyclePlugin-FAILED.yaml
+++ b/kubernetes/example_ApiServerNamespaceLifecyclePlugin/ApiServerNamespaceLifecyclePlugin-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --enable-admission-plugins=other
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerNodeRestrictionPlugin/ApiServerNodeRestrictionPlugin-FAILED.yaml
+++ b/kubernetes/example_ApiServerNodeRestrictionPlugin/ApiServerNodeRestrictionPlugin-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --enable-admission-plugins=other
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerPodSecurityPolicyPlugin/ApiServerPodSecurityPolicyPlugin-FAILED.yaml
+++ b/kubernetes/example_ApiServerPodSecurityPolicyPlugin/ApiServerPodSecurityPolicyPlugin-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --enable-admission-plugins=other
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerProfiling/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerProfiling/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --profiling=true
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerRequestTimeout/api-server-request-timeout-FAILED.yaml
+++ b/kubernetes/example_ApiServerRequestTimeout/api-server-request-timeout-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --request-timeout=1s9m3h
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerSecurePort/api-server-secure-port-FAILED.yaml
+++ b/kubernetes/example_ApiServerSecurePort/api-server-secure-port-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --secure-port=0
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerSecurityContextDenyPlugin/ApiServerSecurityContextDenyPlugin-FAILED.yaml
+++ b/kubernetes/example_ApiServerSecurityContextDenyPlugin/ApiServerSecurityContextDenyPlugin-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --enable-admission-plugins=other
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerServiceAccountKeyFile/ApiServerServiceAccountKeyFile-FAILED.yaml
+++ b/kubernetes/example_ApiServerServiceAccountKeyFile/ApiServerServiceAccountKeyFile-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --service-account-key-file=sdfsdf\dsadsapem
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerServiceAccountLookup/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerServiceAccountLookup/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --service-account-lookup=false
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerServiceAccountPlugin/ApiServerServiceAccountPlugin-FAILED.yaml
+++ b/kubernetes/example_ApiServerServiceAccountPlugin/ApiServerServiceAccountPlugin-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --enable-admission-plugins=other
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerStrongCryptographicCiphers/ApiServerStrongCryptographicCiphers-FAILED.yaml
+++ b/kubernetes/example_ApiServerStrongCryptographicCiphers/ApiServerStrongCryptographicCiphers-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_64_GCM_SHA256
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerTlsCertAndKey/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerTlsCertAndKey/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerTokenAuthFile/ApiServerTokenAuthFile-FAILED.yaml
+++ b/kubernetes/example_ApiServerTokenAuthFile/ApiServerTokenAuthFile-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --token-auth-file=some_file
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerkubeletCertificateAuthority/ApiServerkubeletCertificateAuthority-FAILED.yaml
+++ b/kubernetes/example_ApiServerkubeletCertificateAuthority/ApiServerkubeletCertificateAuthority-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ControllerManagerBindAddress/ControllerManagerBindAddress-FAILED.yaml
+++ b/kubernetes/example_ControllerManagerBindAddress/ControllerManagerBindAddress-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-controller-manager
     - --bind-address=0.0.0.0
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_DockerSocketVolume/cloudwatch-agent-1PASSED-1FAILED.yaml
+++ b/kubernetes/example_DockerSocketVolume/cloudwatch-agent-1PASSED-1FAILED.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:latest
+          image: amazon/cloudwatch-agent@sha256:00f97435d409402ffe492c913fb4c56b7b9794479812891a93b49b43a01303d6 # latest
           imagePullPolicy: Always
           #ports:
           #  - containerPort: 8125
@@ -400,7 +400,7 @@ spec:
       # See https://github.com/fluent/fluentd-kubernetes-daemonset/issues/90
       initContainers:
         - name: copy-fluentd-config
-          image: busybox
+          image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e # latest@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e # latest
           command: ['sh', '-c', 'cp /config-volume/..data/* /fluentd/etc']
           volumeMounts:
             - name: config-volume
@@ -408,11 +408,11 @@ spec:
             - name: fluentdconf
               mountPath: /fluentd/etc
         - name: update-log-driver
-          image: busybox
+          image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e # latest@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e # latest
           command: ['sh','-c','']
       containers:
         - name: fluentd-cloudwatch
-          image: fluent/fluentd-kubernetes-daemonset:v1.3.3-debian-cloudwatch-1.4
+          image: fluent/fluentd-kubernetes-daemonset@sha256:582770d951f81e0971e852089239ced0186e0bdc3226daf16b99ca4cc22de4f7 # v1.3.3-debian-cloudwatch-1.4
           env:
             - name: REGION
               valueFrom:

--- a/kubernetes/example_DropCapabilities/pod-drop-none-FAILED.yaml
+++ b/kubernetes/example_DropCapabilities/pod-drop-none-FAILED.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: main
-      image: fedora
+      image: fedora@sha256:498c452f32a739b61f0ef215bce9924ebc4866cbe44710f58157d77723b7a6d2 # latest
       command: ["/bin/sleep", "999999"]
 
 # kubectl exec -it pod-drop-none -- bash

--- a/kubernetes/example_EtcdAutoTls/Etcd-FAILED.yaml
+++ b/kubernetes/example_EtcdAutoTls/Etcd-FAILED.yaml
@@ -14,7 +14,7 @@ spec:
   - command:
     - etcd
     - --auto-tls=true
-    image: k8s.gcr.io/etcd-amd64:3.2.18
+    image: k8s.gcr.io/etcd-amd64@sha256:b960569ade5f37205a033dcdc3191fe99dc95b15c6795a6282859070ec2c6124 # 3.2.18
     imagePullPolicy: IfNotPresent
     livenessProbe:
       exec:

--- a/kubernetes/example_EtcdCertAndKey/Etcd-FAILED.yaml
+++ b/kubernetes/example_EtcdCertAndKey/Etcd-FAILED.yaml
@@ -14,7 +14,7 @@ spec:
   - command:
     - etcd
     - --cert-file=/etc/kubernetes/pki/etcd/server.crt
-    image: k8s.gcr.io/etcd-amd64:3.2.18
+    image: k8s.gcr.io/etcd-amd64@sha256:b960569ade5f37205a033dcdc3191fe99dc95b15c6795a6282859070ec2c6124 # 3.2.18
     imagePullPolicy: IfNotPresent
     livenessProbe:
       exec:

--- a/kubernetes/example_EtcdClientCertAuth/Etcd-FAILED.yaml
+++ b/kubernetes/example_EtcdClientCertAuth/Etcd-FAILED.yaml
@@ -14,7 +14,7 @@ spec:
   - command:
     - etcd
     - --client-cert-auth=false
-    image: k8s.gcr.io/etcd-amd64:3.2.18
+    image: k8s.gcr.io/etcd-amd64@sha256:b960569ade5f37205a033dcdc3191fe99dc95b15c6795a6282859070ec2c6124 # 3.2.18
     imagePullPolicy: IfNotPresent
     livenessProbe:
       exec:

--- a/kubernetes/example_EtcdPeerFiles/EtcdPeerFiles-FAILED.yaml
+++ b/kubernetes/example_EtcdPeerFiles/EtcdPeerFiles-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - etcd
     - --peer-cert-file=file.pem
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_HostPort/DS-node-exporter-FAILED.yaml
+++ b/kubernetes/example_HostPort/DS-node-exporter-FAILED.yaml
@@ -16,7 +16,7 @@ spec:
             - --web.listen-address=0.0.0.0:9100
             - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
             - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
-          image: quay.io/prometheus/node-exporter:v0.18.1
+          image: quay.io/prometheus/node-exporter@sha256:a2f29256e53cc3e0b64d7a472512600b2e9410347d53cdc85b49f659c17e02ee # v0.18.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3

--- a/kubernetes/example_KubeControllerManagerBlockProfiles/ApiServer-FAILED.yaml
+++ b/kubernetes/example_KubeControllerManagerBlockProfiles/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-controller-manager
     -  --profiling=true
-    image: gcr.io/google_containers/kube-controller-manager-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:f469870cc41473e986e3261e05385cd29e4c59e0c88e697c8a1f261abd6f1072 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_KubeControllerManagerRootCAFile/ApiServer-FAILED.yaml
+++ b/kubernetes/example_KubeControllerManagerRootCAFile/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-controller-manager
     -  --root-ca-file=file.txt
-    image: gcr.io/google_containers/kube-controller-manager-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:f469870cc41473e986e3261e05385cd29e4c59e0c88e697c8a1f261abd6f1072 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_KubeControllerManagerServiceAccountCredentials/ApiServer-FAILED.yaml
+++ b/kubernetes/example_KubeControllerManagerServiceAccountCredentials/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-controller-manager
     - --use-service-account-credentials=false
-    image: gcr.io/google_containers/kube-controller-manager-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:f469870cc41473e986e3261e05385cd29e4c59e0c88e697c8a1f261abd6f1072 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_KubeControllerManagerServiceAccountPrivateKeyFile/ApiServer-FAILED.yaml
+++ b/kubernetes/example_KubeControllerManagerServiceAccountPrivateKeyFile/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-controller-manager
     -  --service-account-private-key-file=public.txt
-    image: gcr.io/google_containers/kube-controller-manager-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:f469870cc41473e986e3261e05385cd29e4c59e0c88e697c8a1f261abd6f1072 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_KubeControllerManagerTerminatedPods/ApiServer-FAILED.yaml
+++ b/kubernetes/example_KubeControllerManagerTerminatedPods/ApiServer-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-controller-manager
-    image: gcr.io/google_containers/kube-controller-manager-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:f469870cc41473e986e3261e05385cd29e4c59e0c88e697c8a1f261abd6f1072 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_KubeletCryptographicCiphers/KubeletCryptographicCiphers-FAILED.yaml
+++ b/kubernetes/example_KubeletCryptographicCiphers/KubeletCryptographicCiphers-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kubelet
     - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_64_GCM_SHA256
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_KubernetesDashboard/kube-dashboard-FAILED.yaml
+++ b/kubernetes/example_KubernetesDashboard/kube-dashboard-FAILED.yaml
@@ -168,7 +168,7 @@ spec:
       serviceAccountName: helm-kubernetes-dashboard
       containers:
       - name: kubernetes-dashboard
-        image: "k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1"
+        image: "k8s.gcr.io/kubernetes-dashboard-amd64@sha256:0ae6b69432e78069c5ce2bcde0fe409c5c4d6f0f4d9cd50a17974fea38898747 # v1.10.1"
         imagePullPolicy: IfNotPresent
         args:
           - --auto-generate-certificates

--- a/kubernetes/example_KubletRotateCertificates/KubletRotateCertificates-FAILED.yaml
+++ b/kubernetes/example_KubletRotateCertificates/KubletRotateCertificates-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kubelet
     - --rotate-certificates=false
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_LivenessReadiness/pod-liveness-readiness-2pods.yaml
+++ b/kubernetes/example_LivenessReadiness/pod-liveness-readiness-2pods.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: k8s.gcr.io/busybox
+    image: k8s.gcr.io/busybox@sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 # latest@sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 # latest
     args:
     - /bin/sh
     - -c
@@ -27,7 +27,7 @@ spec:
       initialDelaySeconds: 5
       periodSeconds: 5
   - name: noliveness
-    image: k8s.gcr.io/busybox
+    image: k8s.gcr.io/busybox@sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 # latest@sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 # latest
     args:
     - /bin/sh
     - -c

--- a/kubernetes/example_RootContainersHighUID/rootContainersHighUIDFAILED.yaml
+++ b/kubernetes/example_RootContainersHighUID/rootContainersHighUIDFAILED.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: main
-    image: alpine
+    image: alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
     command: ["/bin/sleep", "999999"]
 ---
 # Pod runAsUser not set, container runAsUser not set or < 10000 (FAILED)
@@ -17,7 +17,7 @@ metadata:
 spec:
   containers:
   - name: main
-    image: alpine
+    image: alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
     command: ["/bin/sleep", "999999"]
     securityContext:
       runAsUser: 0
@@ -32,10 +32,10 @@ spec:
     runAsUser: 11000
   containers:
   - name: main
-    image: alpine
+    image: alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
     command: ["/bin/sleep", "999999"]
   - name: main2
-    image: alpine
+    image: alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
     command: ["/bin/sleep", "999999"]
     securityContext:
       runAsUser: 0
@@ -50,8 +50,8 @@ spec:
     runAsUser: 1000
   containers:
   - name: main
-    image: alpine
+    image: alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
     command: ["/bin/sleep", "999999"]
   - name: main2
-    image: alpine
+    image: alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
     command: ["/bin/sleep", "999999"]

--- a/kubernetes/example_SchedulerBindAddress/SchedulerBindAddress-FAILED.yaml
+++ b/kubernetes/example_SchedulerBindAddress/SchedulerBindAddress-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-scheduler
     - --bind-address=0.0.0.0
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_SchedulerProfiling/SchedulerProfiling-FAILED.yaml
+++ b/kubernetes/example_SchedulerProfiling/SchedulerProfiling-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-scheduler
     - --profiling=true
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_Seccomp/pod-seccomp-FAILED.yaml
+++ b/kubernetes/example_Seccomp/pod-seccomp-FAILED.yaml
@@ -13,7 +13,7 @@ spec:
     emptyDir: {}
   containers:
   - name: sec-ctx-demo
-    image: busybox
+    image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e # latest
     command: [ "sh", "-c", "sleep 1h" ]
     volumeMounts:
     - name: sec-ctx-vol

--- a/kubernetes/example_Secrets/pod-secretEnvironment-FAILED.yaml
+++ b/kubernetes/example_Secrets/pod-secretEnvironment-FAILED.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
     - name: secret-env-container
-      image: nginx
+      image: nginx@sha256:6e23479198b998e5e25921dff8455837c7636a67111a04a635cf1bb363d199dc # latest@sha256:6e23479198b998e5e25921dff8455837c7636a67111a04a635cf1bb363d199dc # latest
       env:
         - name: SECRET_USERNAME
           valueFrom:
@@ -54,7 +54,7 @@ metadata:
 spec:
   containers:
     - name: envars-test-container
-      image: nginx
+      image: nginx@sha256:6e23479198b998e5e25921dff8455837c7636a67111a04a635cf1bb363d199dc # latest@sha256:6e23479198b998e5e25921dff8455837c7636a67111a04a635cf1bb363d199dc # latest
       envFrom:
         - secretRef:
             name: test-secret

--- a/kubernetes/example_ServiceAccountTokens/ServiceAccountTokensFAILED.yaml
+++ b/kubernetes/example_ServiceAccountTokens/ServiceAccountTokensFAILED.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: main
-      image: alpine
+      image: alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
       command: ["/bin/sleep", "999999"]
 ---
 # automountServiceAccountToken == True (FAILED)
@@ -18,7 +18,7 @@ spec:
   automountServiceAccountToken: true
   containers:
     - name: main
-      image: alpine
+      image: alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # latest
       command: ["/bin/sleep", "999999"]
 
 # kubectl describe pods # You will see default token mounted as a volume

--- a/kubernetes/example_WildcardEntities/nginx-app.yaml
+++ b/kubernetes/example_WildcardEntities/nginx-app.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d # 1.14.2
           ports:
             - containerPort: 80
 ---

--- a/terraform/aws/vpc/vpc_peering_route_table_with_unrestricted_cidr.tf
+++ b/terraform/aws/vpc/vpc_peering_route_table_with_unrestricted_cidr.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "<= 3.49.0"
+      version = "6.43.0"
     }
   }
 }

--- a/terraform/digitalocean/compute/terraform.tf
+++ b/terraform/digitalocean/compute/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "2.17.1"
+      version = "2.85.0"
     }
   }
 }

--- a/terraform/digitalocean/droplet/terraform.tf
+++ b/terraform/digitalocean/droplet/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "2.17.1"
+      version = "2.85.0"
     }
   }
 }

--- a/terraform/digitalocean/loadbalancing/terraform.tf
+++ b/terraform/digitalocean/loadbalancing/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "2.17.1"
+      version = "2.85.0"
     }
   }
 }

--- a/terraform/digitalocean/spaces/terraform.tf
+++ b/terraform/digitalocean/spaces/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "2.17.1"
+      version = "2.85.0"
     }
   }
 }

--- a/terraform/openstack/fw/terraform.tf
+++ b/terraform/openstack/fw/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "terraform-provider-openstack/openstack"
-      version = "1.45.0"
+      version = "3.4.0"
     }
   }
 }

--- a/terraform/oracle/objectstorage_bucket/objectstorage_bucket.tf
+++ b/terraform/oracle/objectstorage_bucket/objectstorage_bucket.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "4.69.0"
+      version = "8.12.0"
     }
   }
 }


### PR DESCRIPTION
Automated dependency pinning by [ghat](https://github.com/JamesWoolfenden/ghat).

Pins GitHub Actions, pre-commit hooks, Terraform modules/providers, Dockerfiles, and Kubernetes images to SHA digests.