### PR TITLE
chore: pin dependencies to immutable SHAs via ghat

### DIFF
--- a/kubernetes/AllowedCapabilities/cassandra-FAILED.yaml
+++ b/kubernetes/AllowedCapabilities/cassandra-FAILED.yaml
@@ -34,7 +34,7 @@ spec:
       terminationGracePeriodSeconds: 1800
       containers:
       - name: cassandra
-        image: gcr.io/google-samples/cassandra@sha256:7a3d20afa0a46ed073a5c587b4f37e21fa860e83c60b9c42fec1e1e739d64007 # v13
+        image: gcr.io/google-samples/cassandra@sha256:7eed23532e59f9ea03260d161f7554df1f8cc2aae80bfe9e6e027aa1aeb264d0 # v13
         imagePullPolicy: Always
         ports:
         - containerPort: 7000
@@ -95,7 +95,7 @@ spec:
         - name: cassandra-data
           mountPath: /cassandra_data
       - name: cassandra
-        image: gcr.io/google-samples/cassandra@sha256:7a3d20afa0a46ed073a5c587b4f37e21fa860e83c60b9c42fec1e1e739d64007 # v13
+        image: gcr.io/google-samples/cassandra@sha256:7eed23532e59f9ea03260d161f7554df1f8cc2aae80bfe9e6e027aa1aeb264d0 # v13
         imagePullPolicy: Always
         ports:
         - containerPort: 7000

--- a/kubernetes/DefaultNamespace/nginx-statefulset-FAILED.yaml
+++ b/kubernetes/DefaultNamespace/nginx-statefulset-FAILED.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim@sha256:8b4501fe0fe221df663c22e16539f399e89594552f400408303c42f3dd8d0e52 # 0.8
+        image: k8s.gcr.io/nginx-slim@sha256:ce45bf76c527594f60b5885555dcc6372b5bc8f3539b36314c22e4e079d88cff # 0.8
         ports:
         - containerPort: 80
           name: web

--- a/kubernetes/example_ApiServerAdmissionControlAlwaysAdmit/ApiServerAdmissionControlAlwaysAdmit-FAILED.yaml
+++ b/kubernetes/example_ApiServerAdmissionControlAlwaysAdmit/ApiServerAdmissionControlAlwaysAdmit-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
     - command:
         - kube-apiserver
         - --enable-admission-plugins=AlwaysAdmit
-      image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+      image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
       livenessProbe:
         failureThreshold: 8
         httpGet:

--- a/kubernetes/example_ApiServerAlwaysPullImagesPlugin/ApiServerAlwaysPullImagesPlugin-FAILED.yaml
+++ b/kubernetes/example_ApiServerAlwaysPullImagesPlugin/ApiServerAlwaysPullImagesPlugin-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --enable-admission-plugins=other
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAnonymousAuth/ApiServer-AnonymousAuth-True-FAILED.yaml
+++ b/kubernetes/example_ApiServerAnonymousAuth/ApiServer-AnonymousAuth-True-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --anonymous-auth=true
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuditLog/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuditLog/ApiServer-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuditLogMaxAge/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuditLogMaxAge/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --audit-log-maxage=10
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuditLogMaxBackup/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuditLogMaxBackup/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --profiling=true
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuditLogMaxSize/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuditLogMaxSize/ApiServer-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuthorizationModeNode/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuthorizationModeNode/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --authorization-mode=RBAC
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuthorizationModeNotAlwaysAllow/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuthorizationModeNotAlwaysAllow/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --authorization-mode=AlwaysAllow
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerAuthorizationModeRBAC/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerAuthorizationModeRBAC/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --authorization-mode=Node
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerBasicAuthFile/ApiServerBasicAuthFile-FAILED.yaml
+++ b/kubernetes/example_ApiServerBasicAuthFile/ApiServerBasicAuthFile-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --basic-auth-file=some_file
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerEncryptionProviders/ApiServerEncryptionProviders-FAILED.yaml
+++ b/kubernetes/example_ApiServerEncryptionProviders/ApiServerEncryptionProviders-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerEtcdCaFile/example_ApiServerEtcdCaFile-FAILED.yaml
+++ b/kubernetes/example_ApiServerEtcdCaFile/example_ApiServerEtcdCaFile-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerEtcdCertAndKey/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerEtcdCertAndKey/ApiServer-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerInsecureBindAddress/api-server-insecure-bind-address-FAILED.yaml
+++ b/kubernetes/example_ApiServerInsecureBindAddress/api-server-insecure-bind-address-FAILED.yaml
@@ -25,7 +25,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-apiserver
-        image: k8s.gcr.io/kube-apiserver
+        image: k8s.gcr.io/kube-apiserver@sha256:4ae8c24a97630f8cfc9eed02fb95e2371d172bb231915e83d27f6ea0e64fa297 # v1.36.0
         command:
         - kube-apiserver
         - --insecure-bind-address=192.168.1.1

--- a/kubernetes/example_ApiServerInsecurePort/api-server-insecure-port-FAILED.yaml
+++ b/kubernetes/example_ApiServerInsecurePort/api-server-insecure-port-FAILED.yaml
@@ -25,7 +25,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-apiserver
-        image: k8s.gcr.io/kube-apiserver
+        image: k8s.gcr.io/kube-apiserver@sha256:4ae8c24a97630f8cfc9eed02fb95e2371d172bb231915e83d27f6ea0e64fa297 # v1.36.0
         command:
         - kube-apiserver
         - --insecure-port=80

--- a/kubernetes/example_ApiServerKubeletClientCertAndKey/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerKubeletClientCertAndKey/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --kubelet-client-certificate=/path/to/cert
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerKubeletHttps/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerKubeletHttps/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --kubelet-https=false
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerNamespaceLifecyclePlugin/ApiServerNamespaceLifecyclePlugin-FAILED.yaml
+++ b/kubernetes/example_ApiServerNamespaceLifecyclePlugin/ApiServerNamespaceLifecyclePlugin-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --enable-admission-plugins=other
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerNodeRestrictionPlugin/ApiServerNodeRestrictionPlugin-FAILED.yaml
+++ b/kubernetes/example_ApiServerNodeRestrictionPlugin/ApiServerNodeRestrictionPlugin-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --enable-admission-plugins=other
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerPodSecurityPolicyPlugin/ApiServerPodSecurityPolicyPlugin-FAILED.yaml
+++ b/kubernetes/example_ApiServerPodSecurityPolicyPlugin/ApiServerPodSecurityPolicyPlugin-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --enable-admission-plugins=other
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerProfiling/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerProfiling/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --profiling=true
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerRequestTimeout/api-server-request-timeout-FAILED.yaml
+++ b/kubernetes/example_ApiServerRequestTimeout/api-server-request-timeout-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --request-timeout=1s9m3h
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerSecurePort/api-server-secure-port-FAILED.yaml
+++ b/kubernetes/example_ApiServerSecurePort/api-server-secure-port-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --secure-port=0
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerSecurityContextDenyPlugin/ApiServerSecurityContextDenyPlugin-FAILED.yaml
+++ b/kubernetes/example_ApiServerSecurityContextDenyPlugin/ApiServerSecurityContextDenyPlugin-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --enable-admission-plugins=other
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerServiceAccountKeyFile/ApiServerServiceAccountKeyFile-FAILED.yaml
+++ b/kubernetes/example_ApiServerServiceAccountKeyFile/ApiServerServiceAccountKeyFile-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --service-account-key-file=sdfsdf\dsadsapem
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerServiceAccountLookup/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerServiceAccountLookup/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --service-account-lookup=false
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerServiceAccountPlugin/ApiServerServiceAccountPlugin-FAILED.yaml
+++ b/kubernetes/example_ApiServerServiceAccountPlugin/ApiServerServiceAccountPlugin-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --enable-admission-plugins=other
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerStrongCryptographicCiphers/ApiServerStrongCryptographicCiphers-FAILED.yaml
+++ b/kubernetes/example_ApiServerStrongCryptographicCiphers/ApiServerStrongCryptographicCiphers-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_64_GCM_SHA256
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerTlsCertAndKey/ApiServer-FAILED.yaml
+++ b/kubernetes/example_ApiServerTlsCertAndKey/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerTokenAuthFile/ApiServerTokenAuthFile-FAILED.yaml
+++ b/kubernetes/example_ApiServerTokenAuthFile/ApiServerTokenAuthFile-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-apiserver
     - --token-auth-file=some_file
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ApiServerkubeletCertificateAuthority/ApiServerkubeletCertificateAuthority-FAILED.yaml
+++ b/kubernetes/example_ApiServerkubeletCertificateAuthority/ApiServerkubeletCertificateAuthority-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_ControllerManagerBindAddress/ControllerManagerBindAddress-FAILED.yaml
+++ b/kubernetes/example_ControllerManagerBindAddress/ControllerManagerBindAddress-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-controller-manager
     - --bind-address=0.0.0.0
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_DockerSocketVolume/cloudwatch-agent-1PASSED-1FAILED.yaml
+++ b/kubernetes/example_DockerSocketVolume/cloudwatch-agent-1PASSED-1FAILED.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent@sha256:00f97435d409402ffe492c913fb4c56b7b9794479812891a93b49b43a01303d6 # latest
+          image: amazon/cloudwatch-agent@sha256:193995a0add1ce16b978422c042fb9e97a1b29e71714aece7ee428e8a76cd052 # latest
           imagePullPolicy: Always
           #ports:
           #  - containerPort: 8125
@@ -412,7 +412,7 @@ spec:
           command: ['sh','-c','']
       containers:
         - name: fluentd-cloudwatch
-          image: fluent/fluentd-kubernetes-daemonset@sha256:582770d951f81e0971e852089239ced0186e0bdc3226daf16b99ca4cc22de4f7 # v1.3.3-debian-cloudwatch-1.4
+          image: fluent/fluentd-kubernetes-daemonset@sha256:0ef851472eb5e52040b5e02fa91592657d437a63778598821a82a71141fc53c1 # v1.3.3-debian-cloudwatch-1.4
           env:
             - name: REGION
               valueFrom:

--- a/kubernetes/example_DropCapabilities/pod-drop-none-FAILED.yaml
+++ b/kubernetes/example_DropCapabilities/pod-drop-none-FAILED.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: main
-      image: fedora@sha256:498c452f32a739b61f0ef215bce9924ebc4866cbe44710f58157d77723b7a6d2 # latest
+      image: fedora@sha256:5d5a02b873d298da9bca4b84440c5cd698b0832560c850d92cf389cef58bc549 # latest
       command: ["/bin/sleep", "999999"]
 
 # kubectl exec -it pod-drop-none -- bash

--- a/kubernetes/example_EtcdAutoTls/Etcd-FAILED.yaml
+++ b/kubernetes/example_EtcdAutoTls/Etcd-FAILED.yaml
@@ -14,7 +14,7 @@ spec:
   - command:
     - etcd
     - --auto-tls=true
-    image: k8s.gcr.io/etcd-amd64@sha256:b960569ade5f37205a033dcdc3191fe99dc95b15c6795a6282859070ec2c6124 # 3.2.18
+    image: k8s.gcr.io/etcd-amd64@sha256:822af1b11c8ec54d5f861d0238b8376623cb4802bb7c983218d909a3814de3ef # 3.2.18
     imagePullPolicy: IfNotPresent
     livenessProbe:
       exec:

--- a/kubernetes/example_EtcdCertAndKey/Etcd-FAILED.yaml
+++ b/kubernetes/example_EtcdCertAndKey/Etcd-FAILED.yaml
@@ -14,7 +14,7 @@ spec:
   - command:
     - etcd
     - --cert-file=/etc/kubernetes/pki/etcd/server.crt
-    image: k8s.gcr.io/etcd-amd64@sha256:b960569ade5f37205a033dcdc3191fe99dc95b15c6795a6282859070ec2c6124 # 3.2.18
+    image: k8s.gcr.io/etcd-amd64@sha256:822af1b11c8ec54d5f861d0238b8376623cb4802bb7c983218d909a3814de3ef # 3.2.18
     imagePullPolicy: IfNotPresent
     livenessProbe:
       exec:

--- a/kubernetes/example_EtcdClientCertAuth/Etcd-FAILED.yaml
+++ b/kubernetes/example_EtcdClientCertAuth/Etcd-FAILED.yaml
@@ -14,7 +14,7 @@ spec:
   - command:
     - etcd
     - --client-cert-auth=false
-    image: k8s.gcr.io/etcd-amd64@sha256:b960569ade5f37205a033dcdc3191fe99dc95b15c6795a6282859070ec2c6124 # 3.2.18
+    image: k8s.gcr.io/etcd-amd64@sha256:822af1b11c8ec54d5f861d0238b8376623cb4802bb7c983218d909a3814de3ef # 3.2.18
     imagePullPolicy: IfNotPresent
     livenessProbe:
       exec:

--- a/kubernetes/example_EtcdPeerFiles/EtcdPeerFiles-FAILED.yaml
+++ b/kubernetes/example_EtcdPeerFiles/EtcdPeerFiles-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - etcd
     - --peer-cert-file=file.pem
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_HostPort/DS-node-exporter-FAILED.yaml
+++ b/kubernetes/example_HostPort/DS-node-exporter-FAILED.yaml
@@ -16,7 +16,7 @@ spec:
             - --web.listen-address=0.0.0.0:9100
             - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
             - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
-          image: quay.io/prometheus/node-exporter@sha256:a2f29256e53cc3e0b64d7a472512600b2e9410347d53cdc85b49f659c17e02ee # v0.18.1
+          image: quay.io/prometheus/node-exporter@sha256:0f422f62c15f154af8d8572b23d623aebfb10cec73a5c654d18f911f3f9df241 # v0.18.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3

--- a/kubernetes/example_KubeControllerManagerBlockProfiles/ApiServer-FAILED.yaml
+++ b/kubernetes/example_KubeControllerManagerBlockProfiles/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-controller-manager
     -  --profiling=true
-    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:f469870cc41473e986e3261e05385cd29e4c59e0c88e697c8a1f261abd6f1072 # v1.6.0
+    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:c23a1de9be5a55861f85f153656f4f5f7cf92e6e68c3860bf18276bd6c95ee12 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_KubeControllerManagerRootCAFile/ApiServer-FAILED.yaml
+++ b/kubernetes/example_KubeControllerManagerRootCAFile/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-controller-manager
     -  --root-ca-file=file.txt
-    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:f469870cc41473e986e3261e05385cd29e4c59e0c88e697c8a1f261abd6f1072 # v1.6.0
+    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:c23a1de9be5a55861f85f153656f4f5f7cf92e6e68c3860bf18276bd6c95ee12 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_KubeControllerManagerServiceAccountCredentials/ApiServer-FAILED.yaml
+++ b/kubernetes/example_KubeControllerManagerServiceAccountCredentials/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-controller-manager
     - --use-service-account-credentials=false
-    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:f469870cc41473e986e3261e05385cd29e4c59e0c88e697c8a1f261abd6f1072 # v1.6.0
+    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:c23a1de9be5a55861f85f153656f4f5f7cf92e6e68c3860bf18276bd6c95ee12 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_KubeControllerManagerServiceAccountPrivateKeyFile/ApiServer-FAILED.yaml
+++ b/kubernetes/example_KubeControllerManagerServiceAccountPrivateKeyFile/ApiServer-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-controller-manager
     -  --service-account-private-key-file=public.txt
-    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:f469870cc41473e986e3261e05385cd29e4c59e0c88e697c8a1f261abd6f1072 # v1.6.0
+    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:c23a1de9be5a55861f85f153656f4f5f7cf92e6e68c3860bf18276bd6c95ee12 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_KubeControllerManagerTerminatedPods/ApiServer-FAILED.yaml
+++ b/kubernetes/example_KubeControllerManagerTerminatedPods/ApiServer-FAILED.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - command:
     - kube-controller-manager
-    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:f469870cc41473e986e3261e05385cd29e4c59e0c88e697c8a1f261abd6f1072 # v1.6.0
+    image: gcr.io/google_containers/kube-controller-manager-amd64@sha256:c23a1de9be5a55861f85f153656f4f5f7cf92e6e68c3860bf18276bd6c95ee12 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_KubeletCryptographicCiphers/KubeletCryptographicCiphers-FAILED.yaml
+++ b/kubernetes/example_KubeletCryptographicCiphers/KubeletCryptographicCiphers-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kubelet
     - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_64_GCM_SHA256
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_KubletRotateCertificates/KubletRotateCertificates-FAILED.yaml
+++ b/kubernetes/example_KubletRotateCertificates/KubletRotateCertificates-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kubelet
     - --rotate-certificates=false
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_LivenessReadiness/pod-liveness-readiness-2pods.yaml
+++ b/kubernetes/example_LivenessReadiness/pod-liveness-readiness-2pods.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: k8s.gcr.io/busybox@sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 # latest@sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 # latest
+    image: k8s.gcr.io/busybox@sha256:545e6a6310a27636260920bc07b994a299b6708a1b26910cfefd335fdfb60d2b # latest@sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 # latest
     args:
     - /bin/sh
     - -c
@@ -27,7 +27,7 @@ spec:
       initialDelaySeconds: 5
       periodSeconds: 5
   - name: noliveness
-    image: k8s.gcr.io/busybox@sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 # latest@sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 # latest
+    image: k8s.gcr.io/busybox@sha256:545e6a6310a27636260920bc07b994a299b6708a1b26910cfefd335fdfb60d2b # latest@sha256:d8d3bc2c183ed2f9f10e7258f84971202325ee6011ba137112e01e30f206de67 # latest
     args:
     - /bin/sh
     - -c

--- a/kubernetes/example_SchedulerBindAddress/SchedulerBindAddress-FAILED.yaml
+++ b/kubernetes/example_SchedulerBindAddress/SchedulerBindAddress-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-scheduler
     - --bind-address=0.0.0.0
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_SchedulerProfiling/SchedulerProfiling-FAILED.yaml
+++ b/kubernetes/example_SchedulerProfiling/SchedulerProfiling-FAILED.yaml
@@ -12,7 +12,7 @@ spec:
   - command:
     - kube-scheduler
     - --profiling=true
-    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:80d3750f3e70db2cdc9d1154b78f6c9961ea41513f7f1d3ed77c461ee54d5734 # v1.6.0
+    image: gcr.io/google_containers/kube-apiserver-amd64@sha256:0524beb2e07d6a5d21eb39cb70d82bea093e5f4c9fa5c4bdf2d44e437d425b61 # v1.6.0
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/kubernetes/example_Secrets/pod-secretEnvironment-FAILED.yaml
+++ b/kubernetes/example_Secrets/pod-secretEnvironment-FAILED.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
     - name: secret-env-container
-      image: nginx@sha256:6e23479198b998e5e25921dff8455837c7636a67111a04a635cf1bb363d199dc # latest@sha256:6e23479198b998e5e25921dff8455837c7636a67111a04a635cf1bb363d199dc # latest
+      image: nginx@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de # latest@sha256:6e23479198b998e5e25921dff8455837c7636a67111a04a635cf1bb363d199dc # latest
       env:
         - name: SECRET_USERNAME
           valueFrom:
@@ -54,7 +54,7 @@ metadata:
 spec:
   containers:
     - name: envars-test-container
-      image: nginx@sha256:6e23479198b998e5e25921dff8455837c7636a67111a04a635cf1bb363d199dc # latest@sha256:6e23479198b998e5e25921dff8455837c7636a67111a04a635cf1bb363d199dc # latest
+      image: nginx@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de # latest@sha256:6e23479198b998e5e25921dff8455837c7636a67111a04a635cf1bb363d199dc # latest
       envFrom:
         - secretRef:
             name: test-secret

--- a/kubernetes/example_WildcardEntities/nginx-app.yaml
+++ b/kubernetes/example_WildcardEntities/nginx-app.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx@sha256:f7988fb6c02e0ce69257d9bd9cf37ae20a60f1df7563c3a2a6abe24160306b8d # 1.14.2
+          image: nginx@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de # 1.14.2
           ports:
             - containerPort: 80
 ---


### PR DESCRIPTION
Automated dependency pinning by [ghat](https://github.com/JamesWoolfenden/ghat).

Pins GitHub Actions, pre-commit hooks, Terraform modules/providers, Dockerfiles, and Kubernetes images to SHA digests.